### PR TITLE
add time zone to Travis

### DIFF
--- a/index.js
+++ b/index.js
@@ -461,6 +461,8 @@ function setupTravis(folder) {
   console.log(chalk.green('Setting up .travis.yml'));
 
   const file = `
+before_install:
+- export TZ=America/Los_Angeles
 language: node_js
 node_js: node
 `.trimStart();


### PR DESCRIPTION
I had a react component snapshot test that worked on my laptop fail on Travis, because I was displaying a date in my component, and the date was different in Pacific time from what it was in UTC. After adding the timezone in my .travis.yml, it passed.